### PR TITLE
Update gender-affirming-care.md and update desistance.md

### DIFF
--- a/library/gc-arguments/desistance.md
+++ b/library/gc-arguments/desistance.md
@@ -5,6 +5,27 @@ parent: GC Arguments
 permalink: /library/gc-arguments/desistance/
 ---
 
-# Desistance / detransition
+# Desistance / Detransition
 
-TODO
+Critics often claim gender-affirming care leads to "widespread regret" or "detransition" to question its necessity. These arguments conflate dissatisfaction with the complex, often external reasons people might detransition, while ignoring data showing overwhelmingly positive outcomes for most transgender individuals.
+
+Regret rates for gender-affirming care and social transition are exceptionally rare. (1%) When detransition/desistance occurs, it is overwhelmingly driven by external pressures. Examples such as societal stigma, familial rejection, discrimination in healthcare or employment, or financial barriers to care; rather than dissatisfaction with treatment. For some, detransition reflects evolving self-understanding or nonbinary identity exploration, not regret. [^1]
+
+* A systematic review of 27 studies from 14 different countries which pooled 7,928 transgender and non-binary individuals who received gender-affirming surgeries revealed an overall regret rate of 1%. This varied depending on the procedure (2% for genital reconstruction surgeries (e.g. vaginoplasty) versus less than 1% for chest masculinization surgeries. (e.g. mastectomies) The primary causes of regret involved external pressures rather than medical outcomes. Many faced social stigma, family rejection, or difficulties adapting to new gender roles in both social and family environments. In some cases, patients reported reverting to their original gender presentation to achieve social acceptance, receive better salaries, and preserve relatives and friends relationships.[^1]
+* 2,863 gender-affirming surgery (GAS) procedures were performed on 1,989 patients. Six patients later requested reversal surgery or reverting to their birth-assigned gender. Five patients who underwent surgery elsewhere sought reversals (two) or pursued further transition to another gender (three). Combined, 11 patients sought reversals or additional gender-affirming procedures.[^2]
+* 1,050 individuals who initiated gender-affirming hormone therapy, (GAH) 93% continued treatment, while 4% permanently discontinued. Suicidal ideation was the only factor significantly linked to discontinuation. (temporarily or permanently) Among the 37 who permanently stopped, 14 did so after achieving their gender goals, with only 5 detransitioning. Most who discontinued still identified as transgender, reflecting evolving gender identities rather than rejection of their trans identity.[^3]
+* 548 Australian youth who were referred to a gender diversity service, only 5.3% (29 individuals) re-identified with their birth-registered sex, primarily before or during early assessment stages. Only two patients did so after starting puberty suppression or hormone treatment, representing 1.0% of those who began medical interventions.[^4]
+* 317 transgender youth (208 MtF/109 FtM, average age 8.1 yrs at the start) after an average of 5 years, 7.3% had retransitioned at least once. At the end of the period, 94% identified as binary transgender, while 2.5% (8 youth) identified as cisgender and 3.5% (11 youth) as nonbinary. Retransitions to cisgender were more common among those who initially transitioned before age 6, often occurring before age 10.[^5]
+* A survey of 220 trans youth (mean age 16.07, with 31% boys, 60% girls, and 9% gender diverse) who received gender-affirming medical care found that only 9 (4.09%) reported regret, including cases where some stopped care while others continued.[^6]
+* 235 patients who underwent mastectomy, 139 responded (average age 27.1 years, with 63% identifying as male), and non-responders had longer follow-up periods and lower rates of depression and anxiety, though medication use was similar between groups. Overall, participants reported high satisfaction with their decision (median score of 5.0 out of 5) and low decisional regret (average score of 4.2 out of 100). Among the 19% who reported a change in gender identity since surgery, satisfaction remained high and regret low.[^7]
+* A systematic review compared regret rates after gender-affirming surgery (GAS), which is about 1%, to those after plastic surgeries like breast reconstruction (0 - 47.1%), breast augmentation (5.1 - 9.1%), and body contouring (10.82 - 33.3%), as well as other surgeries such as prostatectomy (30%) and bariatric surgery (up to 19.5%). Major life decisions, including having children (7%) and getting tattoos (16.2%), also showed higher regret rates. Overall, regret after GAS is significantly lower than in these other areas.[^8]
+
+## References
+[^1]: https://pmc.ncbi.nlm.nih.gov/articles/PMC8099405
+[^2]: https://journals.lww.com/plasreconsurg/fulltext/2023/07000/regret_after_gender_affirming_surgery__a.41.aspx
+[^3]: https://www.jahonline.org/article/S1054-139X%2824%2900554-8/fulltext
+[^4]: https://jamanetwork.com/journals/jamapediatrics/article-abstract/2815512
+[^5]: https://publications.aap.org/pediatrics/article/150/2/e2021056082/186992/Gender-Identity-5-Years-After-Social-Transition
+[^6]: https://pubmed.ncbi.nlm.nih.gov/39432272
+[^7]: https://jamanetwork.com/journals/jamasurgery/fullarticle/2808129?guestAccessKey43a62af8-3042-4678-b29d-3430c3ff98c1
+[^8]: https://www.sciencedirect.com/science/article/abs/pii/S0002961024002381

--- a/library/sources/gender-affirming-care.md
+++ b/library/sources/gender-affirming-care.md
@@ -5,7 +5,7 @@ parent: Sources
 permalink: /library/sources/gender-affirming-care
 ---
 
-# Gender-affirming care
+# Gender-Affirming Care (Youth & Adults)
 
 #### Terms
 GAHT
@@ -14,27 +14,46 @@ GAHT
 VTE
 : Venous thromboembolism (blood clots)
 
-* Gender-affirming care reduced depression by 60% and suicidality by 73% of trans adolescents in just one year[^1].
-* The longest study involving trans and nonbinary youth showed reduction in depression and anxiety.[^2]
-* Gender affirmation is linked to improved mental health. There's no evidence it drives youth suicide.[^3]
-* Social interventions have been found to lower the rates of depression and anxiety in trans and nonbinary
-children[^4].
-* Long-term data suggests that gender-affirming hormone therapy has no negative effect on bone[^5][^6].
-* Youth on puberty blockers overwhelmingly chose to start gender-affirming hormones[^6].
-* Current limited evidence suggest that transgender women taking GAHT have increased risks of ischemic stroke and VTE,
-  with the incidence rate (per year) increasing from 0.07% to 0.13% and 0.07% to 0.32%, respectively, compared to cisgender men,
-  and these risk factors should be adequately managed[^7].
-* A review of 27 studies involving almost 8,000 teens and adults who had transgender surgeries, mostly in
-  Europe, the U.S. and Canada, found that on average 1% expressed regret.[^8] Another study of 1,989
-  individuals found that 6 patients (0.3%) requested reversal surgery during the course of 14 months[^9].
+GD
+: Gender dysphoria
+
+NB
+: Non-binary
+
+* A systematic literature review done by Cornell University looked at 55 studies which assessed the effect of gender transition on trans well-being, it found no studies concluding that gender transition causes overall harm.[^1]
+* 55 young trans adults who received puberty suppression followed by cross-sex hormones/gender-affirming surgery had alleviated GD. Psychological functioning had steadily improved and well-being was similar to or better than same-age young adults from the general population.[^2]
+* Gender-affirming care reduced depression by 60% and suicidality by 73% of 104 trans adolescents aged 13 - 20 in just one year.[^3]
+* A 22-year follow-up of a trans man who underwent puberty suppression at 13, started androgen therapy at 17, and had surgeries at 20 and 22 showed no regrets, stable psychological/social/intellectual functioning, and no adverse impacts on brain development, bone health, or metabolic/endocrine parameters. His final height was shorter than average for Dutch males, though physical health and body proportions remained normal.[^4]
+* 201 gender-diverse adolescents had improved psychosocial functioning after 6 months of psychological support. Those who received puberty suppression showed greater improvement after 12 months compared to those only receiving psychological support.[^5]
+* A study of 720 adolescents who started puberty suppression before age 18 found that 98% continued GAHT at follow-up. Discontinuation rates showed no correlation with clinical factors like age at treatment initiation or puberty stage.[^6]
+* Socially transitioned trans children who are supported in their gender identity have developmentally normative levels of depression and only minimal elevations in anxiety.[^7]
+* Use of chosen name in trans/gender non-conforming youth resulted in a 5.37-unit decrease in depressive symptoms, 29% decrease in suicidal ideation, and a 56% decrease in suicidal behavior.[^8]
+* 148 youth (ages 9 - 18) that received GAHT (25 only had puberty suppression) had a 42% decrease of suicidal ideation, 12% decrease of suicide attempts, and 34% decrease for non-suicidal self-injury.[^9]
+* 50 individuals aged 16.2-18.4 years who received endocrine treatment had depression and suicidal ideation which decreased over three waves of questionnaires, while quality of life improved. Regression analysis showed that endocrine intervention was linked to these positive changes, especially in male-to-female (MTF) participants, after accounting for psychiatric medications and counseling.[^10]
+* In a systematic review of three prospective studies with 247 trans adults (180 MTF and 67 FTM), two studies reported significant improvements in psychological functioning (reduced depression, anxiety) at 3-6 months and 12 months compared to baseline. The third study showed enhancements in quality of life at 12 months for both groups, but only MTF participants had a statistically significant increase.[^11]
+* A study involving 913 trans individuals found that those not using cross-sex hormone treatments had a nearly four-fold increased risk of probable depressive disorder, while using CHT was associated with lower levels of depression.[^12]
+* 315 trans/NB individuals (aged 12 - 20) who received GAHT had increased appearance congruence, positive affect, and life satisfaction while decreasing depression and anxiety overall, though suicidal ideation occurred in 3.5% and two participants died by suicide. Improvements in depression and life satisfaction were more pronounced in those designated female at birth, and early initiation of hormone therapy was linked to more positive outcomes. [^13] 
+* 115 trans youth (aged 12 - 18) after gender-affirming medical treatment had significant reductions in body dissatisfaction, victimization, depression, and anxiety, along with improvements in parent support and psychosocial functioning. Higher initial family support, parent acceptance, and lower victimization were associated with better mental health outcomes, and reductions in body dissatisfaction correlated with fewer depression symptoms and improved psychosocial functioning.[^14] 
+* Gender affirmation is linked to improved mental health. There's no evidence it drives youth suicide.[^15] 
+* Long-term data suggests that gender-affirming hormone therapy has no negative effect on bone health[^16] and youth on puberty blockers overwhelmingly chose to start gender-affirming hormones.[^17] 
+* Current limited evidence suggest that transgender women taking GAHT have increased risks of ischemic stroke and VTE, with the incidence rate (per year) increasing from 0.07% to 0.13% and 0.07% to 0.32%, respectively, compared to cisgender men, and these risk factors should be adequately managed.[^18] 
 
 ## References
-[^1]: <https://pubmed.ncbi.nlm.nih.gov/35212746/>
-[^2]: <https://www.nejm.org/doi/full/10.1056/NEJMoa2206297>
-[^3]: <https://www.politifact.com/factchecks/2023/mar/08/matt-walsh/gender-affirmation-is-linked-to-improved-mental-he/>
-[^4]: <https://www.columbiapsychiatry.org/news/gender-affirming-care-saves-lives>
-[^5]: <https://journals.sagepub.com/doi/full/10.1177/20420188221099346>
-[^6]: <https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0243894>
-[^7]: [2019;139:1461–1462. DOI: 10.1161/CIRCULATIONAHA.118.038584](https://www.ahajournals.org/doi/pdf/10.1161/CIRCULATIONAHA.118.038584)
-[^8]: <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8099405/>
-[^9]: <https://journals.lww.com/plasreconsurg/Abstract/9900/_Regret_after_Gender_Affirming_Surgery___A.1529.aspx>
+[^1]: <https://whatweknow.inequality.cornell.edu/topics/lgbt-equality/what-does-the-scholarly-research-say-about-the-well-being-of-transgender-people>
+[^2]: https://www.hbrs.no/wp-content/uploads/2017/05/young-adult-outcome-after-puberty-suppression-2014-de-Vries.pdf
+[^3]: https://jamanetwork.com/journals/jamanetworkopen/fullarticle/2789423
+[^4]: https://pmc.ncbi.nlm.nih.gov/articles/PMC3114100
+[^5]: https://pubmed.ncbi.nlm.nih.gov/26556015
+[^6]: https://www.sciencedirect.com/science/article/abs/pii/S2352464222002541
+[^7]: https://publications.aap.org/pediatrics/article-abstract/137/3/e20153223/81409/Mental-Health-of-Transgender-Children-Who-Are
+[^8]: https://pubmed.ncbi.nlm.nih.gov/29609917
+[^9]: https://publications.aap.org/pediatrics/article/145/4/e20193006/76951/Body-Dissatisfaction-and-Mental-Health-Outcomes-of
+[^10]: https://ijpeonline.biomedcentral.com/articles/10.1186/s13633-020-00078-2
+[^11]: https://www.liebertpub.com/doi/10.1089/trgh.2015.0008
+[^12]: https://www.sciencedirect.com/science/article/abs/pii/S0165032717324400
+[^13]: https://www.nejm.org/doi/10.1056/NEJMoa2206297
+[^14]: https://www.jahonline.org/article/S1054-139X%2824%2900005-3/abstract
+[^15]: https://www.politifact.com/factchecks/2023/mar/08/matt-walsh/gender-affirmation-is-linked-to-improved-mental-he/
+[^16]: https://journals.sagepub.com/doi/full/10.1177/20420188221099346
+[^17]: https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0243894
+[^18]: https://www.ahajournals.org/doi/pdf/10.1161/CIRCULATIONAHA.118.038584


### PR DESCRIPTION
In the gender-affirming-care document, I have added 13 new citations to expand the references; added more context/details to both the existing citations and the new ones.

In the desistance document, I have added an introduction to provide better context, along with 7 new citations to expand the references. Also, I have moved the previous regret study from 'sources.md' to 'desistance.md' since it seems more relevant there.